### PR TITLE
AC6 Remove list with images from fab-navigation-menu and use it to cr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Note: The format of the versioning is **based [Semantic Versioning 2.0.0](https:
 ## Stories
 Format: version number, story identifier, date (mm/dd/yyy), story title
 
+- [0.5.2] ``AC6`` [02/07/2020] Remove list with images from fab-navigation-menu and use it to create list-with-images component
 - [0.5.1] ``AC5`` [02/06/2020] Fab navigation menu component
 - [0.5.0] ``AC4`` [01/23/2020] Navigation Layout and Navigation Menu components
 - [0.4.1] ``AC3`` [01/23/2020] Refactoring sprint

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuetify-component-library",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "author": "Alejandro G. Carlstein Ramos Mejia",
   "scripts": {

--- a/src/components/list-with-images.vue
+++ b/src/components/list-with-images.vue
@@ -1,0 +1,66 @@
+<template>
+  <v-select
+    :items="items"
+    item-text="img"
+    item-value="value"
+    return-object
+    single-line
+    class="ma-2"
+    v-model="selectionValue">
+    <template slot="selection" slot-scope="data">
+      <v-flex xs12>
+        <v-img :src="data.item.img" width="200px" height="40px">
+          <template v-slot:placeholder >
+            <v-row
+              class="fill-height ma-0"
+              align="center"
+              justify="center">
+              <v-progress-circular indeterminate color="grey lighten-5"></v-progress-circular>
+            </v-row>
+          </template>
+          <v-row class="lightbox black--text fill-height">
+            <v-col align="center">
+              <div class="subheading"><strong>{{data.item.title}}</strong></div>
+            </v-col>
+          </v-row>
+        </v-img>
+      </v-flex>
+    </template>
+    <template slot="item" slot-scope="data">
+      <v-flex xs12>
+        <v-img :src="data.item.img" width="200px" height="40px">
+          <template v-slot:placeholder>
+            <v-row
+              class="fill-height ma-0"
+              align="center"
+              justify="center">
+              <v-progress-circular indeterminate color="grey lighten-5"></v-progress-circular>
+            </v-row>
+          </template>
+          <v-row class="lightbox black--text fill-height">
+            <v-col align="center">
+              <div class="subheading"><strong>{{data.item.title}}</strong></div>
+            </v-col>
+          </v-row>
+        </v-img>
+      </v-flex>
+    </template>
+  </v-select>
+</template>
+
+<script>
+export default {
+  name: 'list-with-images',
+  props: ['items', 'value'],
+  computed: {
+    selectionValue: {
+      get () {
+        return this.value
+      },
+      set (val) {
+        this.$emit('input', val)
+      }
+    }
+  }
+}
+</script>

--- a/src/components/navigation/fab-navigation-menu.vue
+++ b/src/components/navigation/fab-navigation-menu.vue
@@ -107,53 +107,7 @@
                   <v-card-subtitle>
                     <strong>Transition</strong>
                   </v-card-subtitle>
-                  <v-select
-                    :items="transitions"
-                    v-model="transition"
-                    item-text="img"
-                    item-value="value"
-                    return-object
-                    single-line
-                    class="ma-2">
-                    <template slot="selection" slot-scope="data">
-                      <v-flex xs12>
-                        <v-img :src="data.item.img" width="200px" height="40px">
-                          <template v-slot:placeholder >
-                            <v-row
-                              class="fill-height ma-0"
-                              align="center"
-                              justify="center">
-                              <v-progress-circular indeterminate color="grey lighten-5"></v-progress-circular>
-                            </v-row>
-                          </template>
-                          <v-row class="lightbox black--text fill-height">
-                            <v-col align="center">
-                              <div class="subheading"><strong>{{data.item.title}}</strong></div>
-                            </v-col>
-                          </v-row>
-                        </v-img>
-                      </v-flex>
-                    </template>
-                    <template slot="item" slot-scope="data">
-                      <v-flex xs12>
-                        <v-img :src="data.item.img" width="200px" height="40px">
-                          <template v-slot:placeholder>
-                            <v-row
-                              class="fill-height ma-0"
-                              align="center"
-                              justify="center">
-                              <v-progress-circular indeterminate color="grey lighten-5"></v-progress-circular>
-                            </v-row>
-                          </template>
-                          <v-row class="lightbox black--text fill-height">
-                            <v-col align="center">
-                              <div class="subheading"><strong>{{data.item.title}}</strong></div>
-                            </v-col>
-                          </v-row>
-                        </v-img>
-                      </v-flex>
-                    </template>
-                  </v-select>
+                  <list-with-images :items="transitions" v-model="transition" />
                 </v-card>
               </v-col>
               <v-col cols="12" sm="6" md="4">
@@ -170,10 +124,12 @@
 
 <script>
 import dialogCmp from '../dialog-cmp.vue'
+import listWithImages from '../list-with-images.vue'
 export default {
   name: 'fab-navigation-menu',
   components: {
-    dialogCmp
+    dialogCmp,
+    listWithImages
   },
   data: () => ({
     direction: 'right',


### PR DESCRIPTION
Remove list with images from fab-navigation-menu and use it to create list-with-images component.
Note: Currently, we are not adding more flexibility on this list unless needed.